### PR TITLE
fix: fixed wrong import names

### DIFF
--- a/src/key_exchange/sigma.rs
+++ b/src/key_exchange/sigma.rs
@@ -1,5 +1,5 @@
 use crate::key_exchange::KeyExchange;
-use crate::key_exchange::KeyExchangeComm;
+use crate::key_exchange::KeyExchangeProtocol;
 
 pub struct SigmaI();
 pub struct SigmaR();

--- a/src/key_exchange/triple_diffie.rs
+++ b/src/key_exchange/triple_diffie.rs
@@ -1,5 +1,5 @@
 use crate::key_exchange::KeyExchange;
-use crate::key_exchange::KeyExchangeComm;
+use crate::key_exchange::KeyExchangeProtocol;
 
 
 pub struct TripleDiffie();

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,17 +1,17 @@
-use crate::key_exchange::KeyExchangeComm;
+use crate::key_exchange::KeyExchangeProtocol;
 use crate::oprf::*;
 use crate::key_exchange::sigma::*;
 use crate::key_exchange::triple_diffie::*;
 
 // Opaque can take an OPRF type and a Key Exchange
 
-pub struct Opaque<T: KeyExchangeComm, U: Oprf> {
+pub struct Opaque<T: KeyExchangeProtocol, U: Oprf> {
     key_exchange: T,
     oprf: U,
 }
 
 
-impl<T: KeyExchangeComm, U: Oprf> Opaque<T, U> {
+impl<T: KeyExchangeProtocol, U: Oprf> Opaque<T, U> {
     pub fn registration(&self) {
         self.key_exchange.initiate_handshake();
     }


### PR DESCRIPTION
I tried running the project but apparently on the latest commits KeyExchangeComm was renamed to KeyExchangeProtocol and some imports were not renamed as well.

Just thought that it would be cool to contribute with this awesome project 😉 